### PR TITLE
Don't link/output js.file if no inline-js is there

### DIFF
--- a/bin/crisper
+++ b/bin/crisper
@@ -49,7 +49,9 @@ var docText = '';
 function processSource() {
   var split = crisp.split(docText, outScriptUri);
   fs.writeFileSync(outhtml, split.html, 'utf-8');
-  fs.writeFileSync(outscript, split.js, 'utf-8');
+  if (split.js) {
+    fs.writeFileSync(outscript, split.js, 'utf-8');
+  }
 }
 
 if (args.source) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ var noSemiColonInsertion = /\/\/|;\s*$|\*\/\s*$/;
 
 function split(source, jsFileName) {
   var doc = dom5.parse(source);
-  var head = dom5.query(doc, pred.hasTagName('head'));
   var body = dom5.query(doc, pred.hasTagName('body'));
   var scripts = dom5.queryAll(doc, inlineScriptFinder);
 
@@ -52,9 +51,11 @@ function split(source, jsFileName) {
     contents.push(content);
   });
 
-  var newScript = dom5.constructors.element('script');
-  dom5.setAttribute(newScript, 'src', jsFileName);
-  dom5.append(body, newScript);
+  if (contents.length > 0) {
+    var newScript = dom5.constructors.element('script');
+    dom5.setAttribute(newScript, 'src', jsFileName);
+    dom5.append(body, newScript);
+  }
 
   var html = dom5.serialize(doc);
   // newline + semicolon should be enough to capture all cases of concat

--- a/test/test.js
+++ b/test/test.js
@@ -17,29 +17,52 @@ suite('Crisper', function() {
   var crisp = require('../index');
 
   suite('Split API', function() {
-    var obj;
-    setup(function() {
-      obj = crisp.split('', 'foo.js');
+    suite('Default', function () {
+      var obj;
+      setup(function() {
+        obj = crisp.split('<script>var foo = "bar";</script>', 'foo.js');
+      });
+
+      test('return object with js and html properties', function() {
+        assert.property(obj, 'html');
+        assert.property(obj, 'js');
+      });
+
+      test('output html is serialized', function() {
+        assert.typeOf(obj.html, 'string');
+      });
+
+      test('output js is linked via <script> in the output html <body>', function() {
+        var doc = dom5.parse(obj.html);
+        var outscript = dom5.query(doc, pred.AND(
+          pred.hasTagName('script'),
+          pred.hasAttrValue('src', 'foo.js')
+        ));
+        assert.ok(outscript);
+      });
+
     });
 
-    test('return object with js and html properties', function() {
-      assert.property(obj, 'html');
-      assert.property(obj, 'js');
-    });
+    suite('No JS', function() {
+      var obj;
+      setup(function() {
+        obj = crisp.split('<body>Hello World</body>', 'foo.js');
+      });
 
-    test('output html is serialized', function() {
-      assert.typeOf(obj.html, 'string');
-    });
+      test('js property is empty', function() {
+        assert.notOk(obj.js);
+      });
 
-    test('output js is linked via <script> in the output html <body>', function() {
-      var doc = dom5.parse(obj.html);
-      var outscript = dom5.query(doc, pred.AND(
-        pred.hasTagName('script'),
-        pred.hasAttrValue('src', 'foo.js')
-      ));
-      assert.ok(outscript);
-    });
+      test('output js is NOT linked via <script> in the output html <body>', function() {
+        var doc = dom5.parse(obj.html);
+        var outscript = dom5.query(doc, pred.AND(
+          pred.hasTagName('script'),
+          pred.hasAttrValue('src', 'foo.js')
+        ));
+        assert.notOk(outscript);
+      });
 
+    });
   });
 
   suite('Script Outlining', function() {


### PR DESCRIPTION
I know I probably fall into a very small special area with this, but here's my use-case/problem:

While developing a Chrome App with Polymer I want to keep the elements un-vulcanized for easier debugging, but I still need to crisp them for CSP.

Using `gulp-crisper` no output file is created when the JS is empty (e.g. for `iron-flex-layout`) but `crisper` still adds the link to the js file which causes some ugly errors in the console.
![cripser-no-js](https://cloud.githubusercontent.com/assets/809528/9055835/97fe3aac-3a8e-11e5-8956-fea8f34d4e51.PNG)

This PR will only add the script link in the HTML if there is actually JS to link to.

Alternatively I could also send a PR to `gulp-crisper` to remove the [empty check](https://github.com/ragingwind/gulp-crisper/blob/master/index.js#L41) but loading empty js-files somehow doesn't feel right.

All of this is actually a non-issue since nothing breaks, but I like to keep my console as clear as possible :)