### PR TITLE
support type "text/ecmascript-6"

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var inlineScriptFinder = pred.AND(
     pred.NOT(
       pred.hasAttr('type')
     ),
+    pred.hasAttrValue('type', 'text/ecmascript-6'),
     pred.hasAttrValue('type', 'application/javascript'),
     pred.hasAttrValue('type', 'text/javascript')
   ),

--- a/test/html/index.html
+++ b/test/html/index.html
@@ -16,6 +16,9 @@
   <script>var next_statement='found'</script>
   <script src="outofline.js"></script>
   <script type="text/javascript">var three = "three"; //still supported, but don't use!</script>
+  <script type="text/ecmascript-6">
+    var four = "four";
+  </script>
   <script>//# sourceMappingURL=/dev/null</script>
   <script>
   //comment

--- a/test/test.js
+++ b/test/test.js
@@ -130,8 +130,10 @@ suite('Crisper', function() {
         var oneIndex = script.indexOf('one');
         var twoIndex = script.indexOf('two');
         var threeIndex = script.indexOf('three');
+        var fourIndex = script.indexOf('four');
         assert.ok(oneIndex < twoIndex);
         assert.ok(twoIndex < threeIndex);
+        assert.ok(threeIndex < fourIndex);
       });
 
       test('Unknown script types are not removed', function() {


### PR DESCRIPTION
Sometimes it is useful to distinguish whether the JS is written in ES2015. For example you could run babel only on files that are really ES6. One of the ways is to set the type of script to `text/ecmascript-6`.