### PR TITLE
[Breaking] default to script in head

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Library usage:
 var output = crisper({
   source: 'source HTML string',
   jsFileName: 'output js file name.js',
-  scriptInHead: Boolean, //default true
-  onlySplit: Boolean, // default false
-  alwaysWriteScript: Boolean // default false
+  scriptInHead: true, //default true
+  onlySplit: false, // default false
+  alwaysWriteScript: false // default false
 });
 fs.writeFile(htmlOutputFileName, output.html, 'utf-8', ...);
 fs.writeFile(jsOutputFileName, output.js, 'utf-8', ...);
@@ -52,16 +52,16 @@ vulcanize index.html --inline-script | crisper --html build.html --js build.js
 Or programmatically
 
 ```js
-vulcanize.process('index.html', function(err, html) {
+vulcanize.process('index.html', function(err, cb) {
   if (err) {
     return cb(err);
   } else {
     var out = crisper({
       source: html,
       jsFileName: 'name of js file.js',
-      scriptInHead: Boolean, // default true
-      onlySplit: Boolean, // default false
-      alwaysWriteScript: Boolean //default false
+      scriptInHead: true, // default true
+      onlySplit: false, // default false
+      alwaysWriteScript: false //default false
     })
     cb(null, out.html, out.js);
   }

--- a/README.md
+++ b/README.md
@@ -5,34 +5,39 @@
 
 Command line usage:
 
-    cat index.html | crisper -h build.html -j build.js
-    crisper --source index.html --html build.html --js build.js
+```
+cat index.html | crisper -h build.html -j build.js
+crisper --source index.html --html build.html --js build.js
+crisper --html build.html --js build.js index.html
+```
+
+The output html file will load the output js file at the top of `<head>` with a `<script defer>` element.
 
 Optional Flags:
 
-  - `--script-in-head`: in the output HTML file, place the script in `<head>`
-      with the `defer` attribute to provide better loading performance.
-      Note: this will not work correctly if your script contains
-      `document.write` calls.
-  - `--only-split`: Do not write include a `<script>` tag in the output HTML
+  - `--script-in-head=false`
+    - in the output HTML file, place the script at the end of `<body>`
+    - **Note**: Only use this if you need `document.write` support.
+  - `--only-split`
+    - Do not write include a `<script>` tag in the output HTML
       file
-  - `--always-write-script`: Always create a .js file, even without any `<script>`
+  - `--always-write-script`
+    - Always create a .js file, even without any `<script>`
       elements.
 
 Library usage:
 
-    var output = crisper({
-      source: 'source HTML string',
-      jsFileName: 'output js file name.js',
-      scriptInHead: Boolean, //default false
-      onlySplit: Boolean // default false
-    });
-    fs.writeFile(htmlOutputFileName, output.html, 'utf-8', ...);
-    fs.writeFile(jsOutputFileName, output.js, 'utf-8', ...);
-
-Deprecated API:
-
-    var output = crisper.split('source HTML string', 'output js filename.js');
+```js
+var output = crisper({
+  source: 'source HTML string',
+  jsFileName: 'output js file name.js',
+  scriptInHead: Boolean, //default true
+  onlySplit: Boolean, // default false
+  alwaysWriteScript: Boolean // default false
+});
+fs.writeFile(htmlOutputFileName, output.html, 'utf-8', ...);
+fs.writeFile(jsOutputFileName, output.js, 'utf-8', ...);
+```
 
 ## Usage with Vulcanize
 
@@ -40,27 +45,30 @@ When using [vulcanize](https://github.com/Polymer/vulcanize), crisper can handle
 the html string output directly and write the CSP seperated files on the command
 line
 
-    vulcanize index.html --inline-script | crisper --html build.html --js
-    build.js
+```
+vulcanize index.html --inline-script | crisper --html build.html --js build.js
+```
 
 Or programmatically
 
-    vulcanize.process('index.html', function(err, html) {
-      if (err) {
-        return cb(err);
-      } else {
-        var out = crisper({
-          source: html,
-          jsFileName: 'name of js file.js',
-          scriptInHead: Boolean, // default false
-          onlySplit: Boolean // default false
-        })
-        cb(null, out.html, out.js);
-      }
-    });
+```js
+vulcanize.process('index.html', function(err, html) {
+  if (err) {
+    return cb(err);
+  } else {
+    var out = crisper({
+      source: html,
+      jsFileName: 'name of js file.js',
+      scriptInHead: Boolean, // default true
+      onlySplit: Boolean, // default false
+      alwaysWriteScript: Boolean //default false
+    })
+    cb(null, out.html, out.js);
+  }
+});
+```
 
 ## Build Tools
 
 - [gulp-crisper](https://npmjs.com/package/gulp-crisper)
 - [grunt-crisper](https://www.npmjs.com/package/grunt-crisper)
-- *No broccoli plugin yet, will you write it?*

--- a/bin/crisper
+++ b/bin/crisper
@@ -65,23 +65,29 @@ var cli = cliArgs([
   }
 ]);
 
+function getUsage() {
+  return cli.getUsage({
+    title: 'crisper',
+    description: 'Split inline scripts from an HTML file for CSP compliance'
+  });
+}
+
 var args = cli.parse();
 
 if (args.help) {
-  console.log(cli.getUsage({
-    title: 'crisper',
-    description: 'Split inline scripts from an HTML file for CSP compliance'
-  }));
+  console.log(getUsage());
   process.exit(0);
 }
 
 if (!args.html) {
-  console.log('Missing output html file!');
+  console.error('Error: Missing output html file!');
+  console.error(getUsage());
   process.exit(1);
 }
 
 if (!args.js) {
-  console.log('Missing output js file!');
+  console.error('Error: Missing output js file!');
+  console.error(getUsage());
   process.exit(1);
 }
 
@@ -125,7 +131,8 @@ if (source) {
   });
   process.stdin.on('end', processSource);
 } else {
-  console.log('Missing source html file!');
-  console.log('Supply file with STDIN or --source flag');
+  console.error('Missing source html file!');
+  console.error('Supply file with STDIN or --source flag');
+  console.error(getUsage());
   process.exit(1);
 }

--- a/bin/crisper
+++ b/bin/crisper
@@ -12,27 +12,68 @@
 // jshint node: true
 'use strict';
 
-var nopt = require('nopt');
 var fs = require('fs');
 var path = require('path');
 var crisp = require('../index');
 
-var args = nopt(
+var cliArgs = require('command-line-args');
+
+var cli = cliArgs([
   {
-    source: String,
-    html: String,
-    js: String,
-    'script-in-head': Boolean,
-    'only-split': Boolean,
-    'always-write-script': Boolean
+    name: 'source',
+    alias: 's',
+    type: String,
+    defaultOption: true,
+    description: 'Input HTML file to split into HTML and JS files'
   },
   {
-    s: ['--source'],
-    h: ['--html'],
-    j: ['--js']
+    name: 'html',
+    alias: 'h',
+    type: String,
+    description: 'Ouput HTML file'
+  },
+  {
+    name: 'js',
+    alias: 'j',
+    type: String,
+    description: 'Output JS file'
+  },
+  {
+    name: 'script-in-head',
+    type: Boolean,
+    defaultValue: true,
+    description: [
+      'If true, reference the output script in the beginning of <head> as <script defer>.',
+      'If false, reference script at the end of <body> synchronously.',
+      'The deferred script will better parallelize app startup, but will break some APIs like document.write.'
+    ].join(' ')
+  },
+  {
+    name: 'only-split',
+    type: Boolean,
+    description: 'Do not make a <script> tag in the output HTML.'
+  },
+  {
+    name: 'always-write-script',
+    type: Boolean,
+    description: 'Always create an output script file, even if it is empty.'
+  },
+  {
+    name: 'help',
+    type: Boolean,
+    description: 'Print usage'
   }
-);
+]);
 
+var args = cli.parse();
+
+if (args.help) {
+  console.log(cli.getUsage({
+    title: 'crisper',
+    description: 'Split inline scripts from an HTML file for CSP compliance'
+  }));
+  process.exit(0);
+}
 
 if (!args.html) {
   console.log('Missing output html file!');
@@ -44,7 +85,7 @@ if (!args.js) {
   process.exit(1);
 }
 
-var source = args.source || (args.remain && args.remain[0]);
+var source = args.source;
 if (source) {
   source = path.resolve(source);
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var noSemiColonInsertion = /\/\/|;\s*$|\*\/\s*$/;
 module.exports = function crisp(options) {
   var source = options.source || '';
   var jsFileName = options.jsFileName || '';
-  var scriptInHead = options.scriptInHead || false;
+  var scriptInHead = options.scriptInHead !== false;
   var onlySplit = options.onlySplit || false;
   var alwaysWriteScript = options.alwaysWriteScript || false;
 
@@ -82,12 +82,4 @@ module.exports = function crisp(options) {
     html: html,
     js: js
   };
-};
-
-// deprecated
-module.exports.split = function split(source, jsFileName) {
-  return module.exports({
-    source: source,
-    jsFileName: jsFileName
-  });
 };

--- a/package.json
+++ b/package.json
@@ -7,27 +7,24 @@
     "crisper": "bin/crisper"
   },
   "scripts": {
-    "test": "node_modules/.bin/jshint --verbose bin/crisper index.js test/test.js && node_modules/.bin/mocha"
+    "test": "jshint --verbose bin/crisper index.js test/test.js && mocha"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/PolymerLabs/crisper.git"
   },
   "author": "The Polymer Authors",
-  "license": {
-    "type": "BSD-3-Clause",
-    "url": "http://polymer.github.io/LICENSE.txt"
-  },
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/PolymerLabs/crisper/issues"
   },
   "homepage": "https://github.com/PolymerLabs/crisper",
   "dependencies": {
-    "dom5": "^1.0.1",
-    "nopt": "^3.0.1"
+    "command-line-args": "^2.0.2",
+    "dom5": "^1.0.1"
   },
   "devDependencies": {
-    "chai": "^2.2.0",
+    "chai": "^3.4.0",
     "jshint": "^2.6.3",
     "mocha": "^2.2.3"
   }


### PR DESCRIPTION
- Default to a deferred script in `<head>`
- Remove deprecated `crisp.split` API
- Replace nopt with command-line-args

Fixes #22