### PR TITLE
scripts should be wrapped in IIFEs on concatenation

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function crisp(options) {
     }
     var content = dom5.getTextContent(sn).trim();
     // wrap content in immediately invoked function expression (IIFE)
-    let iifeContent = '(function(){\n' + content + '\n})();'
+    var iifeContent = '(function(){\n' + content + '\n})();';
     contents.push(iifeContent);
   });
 

--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ var inlineScriptFinder = pred.AND(
   )
 );
 
-var noSemiColonInsertion = /\/\/|;\s*$|\*\/\s*$/;
-
 module.exports = function crisp(options) {
   var source = options.source || '';
   var jsFileName = options.jsFileName || '';
@@ -43,7 +41,7 @@ module.exports = function crisp(options) {
   var scripts = dom5.queryAll(doc, inlineScriptFinder);
 
   var contents = [];
-  scripts.forEach(function(sn) {
+  scripts.forEach(function (sn) {
     var nidx = sn.parentNode.childNodes.indexOf(sn) + 1;
     var next = sn.parentNode.childNodes[nidx];
     dom5.remove(sn);
@@ -52,12 +50,9 @@ module.exports = function crisp(options) {
       dom5.remove(next);
     }
     var content = dom5.getTextContent(sn).trim();
-    var lines = content.split('\n');
-    var lastline = lines[lines.length - 1];
-    if (!noSemiColonInsertion.test(lastline)) {
-      content += ';';
-    }
-    contents.push(content);
+    // wrap content in immediately invoked function expression (IIFE)
+    let iifeContent = '(function(){\n' + content + '\n})();'
+    contents.push(iifeContent);
   });
 
   if (!onlySplit) {
@@ -75,7 +70,6 @@ module.exports = function crisp(options) {
   }
 
   var html = dom5.serialize(doc);
-  // newline + semicolon should be enough to capture all cases of concat
   var js = contents.join('\n');
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crisper",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Make an HTML file with inline scripts CSP compliant",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Scripts should each be wrapped in immediately invoked function expressions (IIFEs) on concatenation as mentioned in [Effective Javascript by David Herman (chapter 1)](https://books.google.de/books?id=nBuA0hmspdMC&redir_esc=y).
This would avoid several problems, e.g. considering scopes and usage of "use strict";

So instead of:

``` javascript
script_1;
script_2;
...
script_n;
```

The concatenated file should look like:

``` javascript
(function (){
  script_1
})();
(function (){
  script_2
})();
...
(function (){
  script_n
})();
```

Implementation should be easy:

``` javascript
var content = dom5.getTextContent(sn).trim();
// wrap content in immediately invoked function expression (IIFE)
let iifeContent = '(function(){\n' + content + '\n})();'
contents.push(iifeContent);
```
