### PR TITLE
Make sure `--script-in-head=false` works for the CLI binary

### DIFF
--- a/bin/crisper
+++ b/bin/crisper
@@ -40,12 +40,18 @@ var cli = cliArgs([
   },
   {
     name: 'script-in-head',
-    type: Boolean,
+    type: function(s) {
+      if (s && s.toLowerCase() === 'false') {
+        return false;
+      }
+      return true;
+    },
     defaultValue: true,
     description: [
       'If true, reference the output script in the beginning of <head> as <script defer>.',
       'If false, reference script at the end of <body> synchronously.',
-      'The deferred script will better parallelize app startup, but will break some APIs like document.write.'
+      'The deferred script will better parallelize app startup, but will break some APIs like document.write.',
+      'This flag is true by default, disable with --script-in-head=false'
     ].join(' ')
   },
   {


### PR DESCRIPTION
Fixes #27 Can't set `--script-in-head` to false with command line usage?