### PR TITLE
Add support for hash-based CSP with strict-dynamic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Optional Flags:
   - `--always-write-script`
     - Always create a .js file, even without any `<script>`
       elements.
+  - `--csp-hashable-script-loader`
+    - Create a hashable script loader that supports hash-based CSP with strict-dynamic.
+    - A strict CSP could look like this:
+    ```
+    script-src 'strict-dynamic' 'sha256-mUZwR5zj1qMvnzisSvfmC8JczLB0BUKW0Ohr3euDoIA=';
+    object-src 'none';
+    base-uri 'self';
+    ```
   - `-v` | `--version`
     - Prints version number.
 

--- a/bin/crisper
+++ b/bin/crisper
@@ -65,6 +65,15 @@ var cli = cliArgs([
     description: 'Always create an output script file, even if it is empty.'
   },
   {
+    name: 'csp-hashable-script-loader',
+    type: Boolean,
+    description: [
+      'Create a hashable script loader that supports hash-based CSP with strict-dynamic.',
+      'A strict CSP could look like this:\n',
+      ' script-src \'strict-dynamic\' \'sha256-mUZwR5zj1qMvnzisSvfmC8JczLB0BUKW0Ohr3euDoIA=\'; object-src \'none\'; base-uri \'self\''
+    ].join(' ')
+  },
+  {
     name: 'help',
     type: Boolean,
     description: 'Print usage'
@@ -118,6 +127,7 @@ var outScriptUri = path.relative(path.dirname(args.html), args.js);
 var placeInHead = args['script-in-head'];
 var onlySplit = args['only-split'];
 var alwaysWriteScript = args['always-write-script'];
+var cspHashableScriptLoader = args['csp-hashable-script-loader'];
 
 var docText = '';
 
@@ -127,7 +137,8 @@ function processSource() {
     jsFileName: outScriptUri,
     scriptInHead: placeInHead,
     onlySplit: onlySplit,
-    alwaysWriteScript: alwaysWriteScript
+    alwaysWriteScript: alwaysWriteScript,
+    cspHashableScriptLoader: cspHashableScriptLoader
   });
   fs.writeFileSync(outhtml, split.html, 'utf-8');
   if (split.js || split.js === "" && alwaysWriteScript) {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
 // jshint node: true
 'use strict';
 
+var crypto = require("crypto");
 var dom5 = require('dom5');
 var pred = dom5.predicates;
 
@@ -37,6 +38,7 @@ module.exports = function crisp(options) {
   var scriptInHead = options.scriptInHead !== false;
   var onlySplit = options.onlySplit || false;
   var alwaysWriteScript = options.alwaysWriteScript || false;
+  var cspHashableScriptLoader = options.cspHashableScriptLoader || false;
 
   var doc = dom5.parse(source);
   var body = dom5.query(doc, pred.hasTagName('body'));
@@ -64,13 +66,34 @@ module.exports = function crisp(options) {
   if (!onlySplit) {
     if (contents.length > 0 || alwaysWriteScript) {
       var newScript = dom5.constructors.element('script');
-      dom5.setAttribute(newScript, 'src', jsFileName);
+      var comment;
+      if (cspHashableScriptLoader) {
+        // hashable script loader to support hash-based CSP with strict-dynamic.
+        var loader = '// CSP \'strict-dynamic\' compatible script loader. ';
+        loader += 'Add \'strict-dynamic\' and a hash of this script to your CSP.\n';
+        loader += 'var s = document.createElement("script");\n';
+        loader += 's.src = "' + jsFileName + '";\n';
+        loader += 'document.body.appendChild(s);\n';
+        dom5.setTextContent(newScript, loader);
+
+        // Calculate hash of loader script for CSP.
+        var scriptHash = crypto.createHash('sha256');
+        scriptHash.update(loader, 'utf-8');
+        var digest = scriptHash.digest('base64');
+        var commentText = ' CSP hash: \'sha256-' + digest + '\' ';
+        comment = dom5.constructors.comment(commentText);
+      } else {
+        dom5.setAttribute(newScript, 'src', jsFileName);
+      }
       if (scriptInHead) {
         dom5.setAttribute(newScript, 'defer', '');
         head.childNodes.unshift(newScript);
         newScript.parentNode = head;
       } else {
         dom5.append(body, newScript);
+      }
+      if (cspHashableScriptLoader) {
+        dom5.insertBefore(newScript.parentNode, newScript, comment);
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function crisp(options) {
         loader += 'Add \'strict-dynamic\' and a hash of this script to your CSP.\n';
         loader += 'var s = document.createElement("script");\n';
         loader += 's.src = "' + jsFileName + '";\n';
-        loader += 'document.body.appendChild(s);\n';
+        loader += '(document.body||document.head).appendChild(s);\n';
         dom5.setTextContent(newScript, loader);
 
         // Calculate hash of loader script for CSP.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crisper",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Make an HTML file with inline scripts CSP compliant",
   "main": "index.js",
   "bin": {

--- a/test/test.js
+++ b/test/test.js
@@ -107,7 +107,7 @@ suite('Crisper', function() {
         });
       });
 
-      test('script in head with defer attribute', function() {
+      test('script in body', function() {
         var doc = dom5.parse(obj.html);
         var body = dom5.query(doc, pred.hasTagName('body'));
         var script = dom5.query(body, pred.AND(
@@ -118,6 +118,27 @@ suite('Crisper', function() {
         var expected = body.childNodes.length - 1;
         var actual = body.childNodes.indexOf(script);
         assert.equal(expected, actual);
+      });
+    });
+
+    suite('script loaded via hashable inline-script if forced', function() {
+      var obj;
+      setup(function() {
+        obj = crisp({
+          source: '<div></div><script>var a = "b";</script>',
+          jsFileName: 'foo.js',
+          cspHashableScriptLoader: true
+        });
+      });
+
+      test('script loaded through hashable loader script', function() {
+        var doc = dom5.parse(obj.html);
+        var head = dom5.query(doc, pred.hasTagName('head'));
+        var script = dom5.query(head, pred.AND(
+          pred.hasTagName('script'),
+          pred.NOT(pred.hasAttrValue('src', 'foo.js'))
+        ));
+        assert.ok(script);
       });
     });
 


### PR DESCRIPTION
It's not trivial to combine a [strict CSP](https://csp.withgoogle.com/docs/strict-csp.html) (a CSP based on nonces/hashes and 'strict-dynamic') with a Polymer application. Since Polymer apps are usually static (no backend) they're by nature incompatible to CSP nonces.
To make Polymer apps compatible with strict CSP, I added an option to Crisper that loads the externalized script through a loader (inline-)script instead of sourcing the script via _src_. Inline-scripts can be hashed (and therefore allowed in CSP).